### PR TITLE
allow custom hosts in openshift routes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CONTROLLER_NAME  := openshift-lb-controller
-IMAGE := <yourregistry>/$(CONTROLLER_NAME)
+IMAGE := yourregistry/$(CONTROLLER_NAME)
 .PHONY: install_deps build build-image test
 
 test:

--- a/docs/f5.md
+++ b/docs/f5.md
@@ -19,7 +19,7 @@ when HTTP_REQUEST {
     HTTP::header insert X-Forwarded-Inet [IP::version]
     HTTP::header insert X-Forwarded-For "[getfield [IP::remote_addr] % 1]"
     
-    set host [getfield [HTTP::header host] "." 1]
+    set host [HTTP::header host]
     set port [TCP::local_port]
     append host "_$port"
     if { [catch {pool $host} id ] } {
@@ -60,7 +60,7 @@ These annotations can be added to each route in Openshift configuration, and it 
 | route.elisa.fi/method      | GET | string |
 | route.elisa.fi/lbmethod | round-robin | string, look methods below |
 | route.elisa.fi/poolpga | disabled | integer |
-
+| route.elisa.fi/lbenabled | | string |
 
 ### Possible loadbalancing methods in F5:
 
@@ -81,3 +81,8 @@ These annotations can be added to each route in Openshift configuration, and it 
 - ratio-session
 - ratio-least-connections-member
 - ratio-least-connections-node
+
+
+## Custom hosts to F5 (other than `SUFFIXHOST`)
+
+There is possibility to add another hosts than suffixhost to F5. For instance if you want add `foobar.com` route to be exposed through F5, you need to add annotation `route.elisa.fi/lbenabled` to route, the value of annotation does not matter it can be empty (`''`). Please remember that if you need certificates for this host, it needs to be added to F5 manually.

--- a/pkg/controller/plugins.go
+++ b/pkg/controller/plugins.go
@@ -26,9 +26,9 @@ type ProviderInterface interface {
 	// modifies loadbalancer pool
 	ModifyPool(name string, port string, loadBalancingMethod string, pga int) error
 	// creates new monitor
-	CreateMonitor(name string, port string, host string, uri string, httpMethod string, interval int, timeout int) error
+	CreateMonitor(host string, port string, uri string, httpMethod string, interval int, timeout int) error
 	// modifies monitor
-	ModifyMonitor(name string, port string, host string, uri string, httpMethod string, interval int, timeout int) error
+	ModifyMonitor(host string, port string, uri string, httpMethod string, interval int, timeout int) error
 	// adds monitor to pool
 	AddMonitorToPool(name string, port string) error
 	// delete pool member

--- a/pkg/controller/providers/f5/f5.go
+++ b/pkg/controller/providers/f5/f5.go
@@ -155,12 +155,12 @@ func (f5 *ProviderF5) ModifyPool(name string, port string, loadBalancingMethod s
 }
 
 // CreateMonitor creates new monitor
-func (f5 *ProviderF5) CreateMonitor(name string, port string, host string, uri string, httpMethod string, interval int, timeout int) error {
+func (f5 *ProviderF5) CreateMonitor(host string, port string, uri string, httpMethod string, interval int, timeout int) error {
 	scheme := "http"
 	if port == "443" {
 		scheme = "https"
 	}
-	err := f5.session.CreateMonitor(name+"_"+port, scheme, interval, timeout, httpMethod+" "+uri+" HTTP/1.1\r\nHost:"+host+"  \r\nConnection: Close\r\n\r\n", "^HTTP.1.(0|1) ([2|3]0[0-9])", scheme)
+	err := f5.session.CreateMonitor(host+"_"+port, scheme, interval, timeout, httpMethod+" "+uri+" HTTP/1.1\r\nHost:"+host+"  \r\nConnection: Close\r\n\r\n", "^HTTP.1.(0|1) ([2|3]0[0-9])", scheme)
 	if err != nil {
 		if !alreadyExist(err) {
 			return err
@@ -170,7 +170,7 @@ func (f5 *ProviderF5) CreateMonitor(name string, port string, host string, uri s
 }
 
 // ModifyMonitor modifies monitor
-func (f5 *ProviderF5) ModifyMonitor(name string, port string, host string, uri string, httpMethod string, interval int, timeout int) error {
+func (f5 *ProviderF5) ModifyMonitor(host string, port string, uri string, httpMethod string, interval int, timeout int) error {
 	scheme := "http"
 	if port == "443" {
 		scheme = "https"
@@ -180,7 +180,7 @@ func (f5 *ProviderF5) ModifyMonitor(name string, port string, host string, uri s
 		Timeout:    timeout,
 		SendString: httpMethod + " " + uri + " HTTP/1.1\r\nHost:" + host + "  \r\nConnection: Close\r\n\r\n",
 	}
-	err := f5.session.PatchMonitor(name+"_"+port, scheme, config)
+	err := f5.session.PatchMonitor(host+"_"+port, scheme, config)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/providers/fakeprovider/fakeprovider.go
+++ b/pkg/controller/providers/fakeprovider/fakeprovider.go
@@ -58,13 +58,13 @@ func (f *Fakeprovider) ModifyPool(name string, port string, loadBalancingMethod 
 }
 
 // CreateMonitor creates new monitor
-func (f *Fakeprovider) CreateMonitor(name string, port string, host string, uri string, httpMethod string, interval int, timeout int) error {
+func (f *Fakeprovider) CreateMonitor(host string, port string, uri string, httpMethod string, interval int, timeout int) error {
 	f.addCall("CreateMonitor")
 	return nil
 }
 
 // ModifyMonitor modifies monitor
-func (f *Fakeprovider) ModifyMonitor(name string, port string, host string, uri string, httpMethod string, interval int, timeout int) error {
+func (f *Fakeprovider) ModifyMonitor(host string, port string, uri string, httpMethod string, interval int, timeout int) error {
 	f.addCall("ModifyMonitor")
 	return nil
 }


### PR DESCRIPTION
Currently it is only possible to expose `*.something.com` dns name to external loadbalancer. This pull request makes it possible to expose ANY dns name through the external loadbalancer. This can be done by adding `route.elisa.fi/lbenabled` annotation to openshift route. The value of annotation does not matter. However, if you need certificates for your domain these ssl certificates should be added currently manually to loadbalancer configuration.